### PR TITLE
fixes jpush/jpush-api-python-client#15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 
 # command to install dependencies
 install:
-  - pip install requests
   - pip install .
 
 # command to run tests

--- a/README.rst
+++ b/README.rst
@@ -19,15 +19,6 @@ JPush Rest API Documents: `http://docs.jpush.cn/display/dev/REST+API <http://doc
 You can download the latest release file here: `Releases <https://github.com/jpush/jpush-api-python-client/releases>`_
 
 ------------
-Dependencies
-------------
-You need to install requests, the python http library, to use jpush python client.
-
-.. code-block:: sh
-
-    $ sudo pip install requests 
-
-------------
 Installation
 ------------
 To install jpush-api-python-client, simply:

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
+import re
+import ast
 try:
     from setuptools import setup
 except (ImportError):
     from distutils.core import setup
 
-__version__ = '3.0.2'
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+
+with open('jpush/__init__.py', 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
 
 setup(
     name='jpush',
-    version=__version__,
+    version=version,
     description='JPush\'s officially supported Python client library',
     keywords=('JPush', 'JPush API', 'Android Push', 'iOS Push'),
     license='MIT License',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ try:
     from setuptools import setup
 except (ImportError):
     from distutils.core import setup
-from jpush import __version__
 
+__version__ = '3.0.2'
 
 setup(
     name='jpush',


### PR DESCRIPTION
- Get the version from `jpush/__init__.py`
- Remove dependencies block from README.rst
