### PR TITLE
set alert param default to None for  android and winphone

### DIFF
--- a/jpush/push/payload.py
+++ b/jpush/push/payload.py
@@ -3,6 +3,20 @@ import re
 # Valid autobadge values: auto, +N, -N
 VALID_AUTOBADGE = re.compile(r'^(auto|[+-][\d]+)$')
 
+def is_string(s):
+    try:
+        import six
+        string_types = six.string_types
+    except ImportError as e:
+        import sys
+        if sys.version_info[0] <= 2:
+            string_types = basestring
+        else:
+            string_types = str
+    return isinstance(s, string_types)
+
+
+
 def notification(alert=None, ios=None, android=None, winphone=None):
     """Create a notification payload.
 
@@ -46,13 +60,13 @@ def ios(alert=None, badge=None, sound=None, content_available=False,
     """
     payload = {}
     if alert is not None:
-        if not isinstance(alert, str) or isinstance(alert, dict):
+        if not is_string(alert) or isinstance(alert, dict):
             raise ValueError("iOS alert must be a string or dictionary")
         payload['alert'] = alert
     if badge is not None:
-        if not (isinstance(badge, str) or isinstance(badge, int)):
+        if not (is_string(badge) or isinstance(badge, int)):
             raise ValueError("iOS badge must be an integer or string")
-        if isinstance(badge, str) and not VALID_AUTOBADGE.match(badge):
+        if is_string(badge) and not VALID_AUTOBADGE.match(badge):
             raise ValueError("Invalid iOS autobadge value")
         payload['badge'] = badge
     if not sound_disable:

--- a/jpush/push/payload.py
+++ b/jpush/push/payload.py
@@ -66,7 +66,7 @@ def ios(alert=None, badge=None, sound=None, content_available=False,
         payload['extras'] = extras
     return payload
 
-def android(alert, title=None, builder_id=None, extras=None):
+def android(alert=None, title=None, builder_id=None, extras=None):
     """Android specific platform override payload.
 
     All keyword arguments are optional.
@@ -89,7 +89,7 @@ def android(alert, title=None, builder_id=None, extras=None):
     return payload
 
 
-def winphone(alert, title=None, _open_page=None, extras=None):
+def winphone(alert=None, title=None, _open_page=None, extras=None):
     """MPNS specific platform override payload.
 
     Must include exactly one of ``alert``, ``title``, ``_open_page``, or ``extras``.


### PR DESCRIPTION
1. alert parameter  default value is missing, please add it, thank you!
2. if alert/badge is unicode string in python2, ios() call will raise ValueError
