### PR TITLE
fix bugs: lack of brackets

### DIFF
--- a/jpush/push/payload.py
+++ b/jpush/push/payload.py
@@ -47,7 +47,7 @@ def ios(alert=None, badge=None, sound=None, content_available=False,
     """
     payload = {}
     if alert is not None:
-        if not isinstance(alert, str) or isinstance(alert, dict):
+        if not isinstance(alert, (str, dict)):
             raise ValueError("iOS alert must be a string or dictionary")
         payload['alert'] = alert
     if badge is not None:


### PR DESCRIPTION
```if not isinstance(alert, str) or isinstance(alert, dict):```
should be ```if not (isinstance(alert, str) or isinstance(alert, dict)):```
one more easier code: ```if not isinstance(alert, (str, dict)):```