### PR TITLE
[Change] Avoid bare except; keep the original traceback

### DIFF
--- a/jpush/_compat.py
+++ b/jpush/_compat.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+from __future__ import absolute_import
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")

--- a/jpush/core.py
+++ b/jpush/core.py
@@ -1,8 +1,11 @@
+# coding=utf-8
 import json
 import logging
+import sys
 import warnings
 
 import requests
+from ._compat import reraise
 from . import common
 from .push import Push
 from .device import Device
@@ -32,8 +35,10 @@ class JPush(object):
             response = self.session.request(method, url, data=body, params=params, headers=headers, timeout=30)
         except requests.exceptions.ConnectTimeout:
             raise common.APIConnectionException("Connection to api.jpush.cn timed out.")
-        except:
-            raise common.APIConnectionException("Connection to api.jpush.cn error.")
+        except Exception:
+            # keep the original traceback
+            new_exc = common.APIConnectionException("Connection to api.jpush.cn error.")
+            reraise(new_exc, None, sys.exc_info()[-1])
 
         logger.debug("Received %s response. Headers:\n\t%s\nBody:\n\t%s", response.status_code, '\n\t'.join(
                 '%s: %s' % (key, value) for (key, value) in response.headers.items()), response.content)


### PR DESCRIPTION
 - Use `except Exception:` instead of `except:` to avoid bare except.
 - Keep the original traceback when raising the wrapper exception so
   developers could figure out the cause of exception.