### PR TITLE
Fix no encoding declared error in python2.7

### DIFF
--- a/jpush/common.py
+++ b/jpush/common.py
@@ -1,3 +1,5 @@
+#  -*-coding:utf8 -*-
+
 import json
 import logging
 import requests


### PR DESCRIPTION
There are non ascii characters in https://github.com/jpush/jpush-api-python-client/blob/470d2d027c518f18245f0a8a61c93e440a76b551/jpush/common.py#L84, this will raise ```SyntaxError: Non-ASCII character '\xe4' in file /app/.heroku/python/lib/python2.7/site-packages/jpush/common.py on line 84, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details``` error.

This PR fixes this.