### PR TITLE
fix invalid parameter issue of get_status_mesage. 

### DIFF
--- a/examples/report_example.py
+++ b/examples/report_example.py
@@ -21,7 +21,9 @@ def users():
     report.get_users("DAY","2016-04-10","3")
 
 def status():
-    report.get_status_message('3289406737', ['xxx'])
+    msgid = '3289406737'
+    regid = 'xxx'
+    report.get_status_message(int(msgid), [regid])
 
 messages_detail()
 received_detail()

--- a/jpush/report/core.py
+++ b/jpush/report/core.py
@@ -29,6 +29,7 @@ class Report(object):
         return response
 
     def get_status_message(self, msg_id, reg_ids, date=None):
+        import json
         url = common.get_url('report', self.zone) + 'status/message'
         if not isinstance(reg_ids, list):
             reg_ids = [reg_ids]
@@ -38,6 +39,7 @@ class Report(object):
         }
         if date is not None:
             body['date'] = date
+        body = json.dumps(body)
         sm = self.send("POST", url, body = body)
         return sm
 


### PR DESCRIPTION
   Currently the  `def get_status_message(self, msg_id, reg_ids, date=None):` **function** of the `Report` **class** has a bug. Once It was being called, It would always response with `{"error":{"code":3002,"message":"Parameter is invalid, not a valid JSON format"}}` . If we convert the payloads into json format, we will get the decent response. 

